### PR TITLE
Bump Node.js version

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -43,5 +43,5 @@ inputs:
     default: "$Config{installsitescript}/cpanm"
 
 runs:
-  using: "node16"
+  using: "node20"
   main: "dist/index.js"


### PR DESCRIPTION
I can see the warning in the workflows that are using this action:

> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: perl-actions/install-with-cpanm@v1. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.

Fixes #23 